### PR TITLE
feat(cloudinary): add endpoint to fetch images from Cloudinary

### DIFF
--- a/src/controllers/cloudinaryController.js
+++ b/src/controllers/cloudinaryController.js
@@ -1,0 +1,47 @@
+const axios = require('axios');
+require('dotenv').config();
+
+const apiKey = process.env.CLOUDINARY_API_KEY;
+const apiSecret = process.env.CLOUDINARY_API_SECRET;
+const cloudName = 'dolznek84'; // reemplaza con tu nombre real de Cloudinary
+
+const getCloudinaryImages = async (req, res) => {
+  try {
+    if (!apiKey || !apiSecret) {
+      return res.status(500).json({ 
+        success: false, 
+        message: 'Credenciales de Cloudinary no configuradas' 
+      });
+    }
+
+    const url = `https://api.cloudinary.com/v1_1/${cloudName}/resources/image`;
+
+    const response = await axios.get(url, {
+      auth: {
+        username: apiKey,
+        password: apiSecret
+      },
+      params: {
+        max_results: 100
+      }
+    });
+
+    return res.status(200).json({
+      success: true,
+      data: response.data.resources
+    });
+
+  } catch (error) {
+    console.error('Error al obtener imágenes de Cloudinary:', error);
+
+    return res.status(error.response?.status || 500).json({
+      success: false,
+      message: error.response?.data?.error?.message || 'Error al obtener imágenes de Cloudinary',
+      error: error.message
+    });
+  }
+};
+
+module.exports = {
+  getCloudinaryImages
+};

--- a/src/routes/propertyRoutes.js
+++ b/src/routes/propertyRoutes.js
@@ -11,6 +11,7 @@ const {
   deleteProperty
 } = require('../controllers/propertyController');
 const catalogController = require('../controllers/catalogController');
+const cloudinaryController = require('../controllers/cloudinarycontroller');
 
 /**
  * @swagger
@@ -74,6 +75,9 @@ router.get('/catalogs/sale-types', catalogController.getSaleTypes);
 router.get('/catalogs/legal-statuses', catalogController.getLegalStatuses);
 router.get('/catalogs/states', catalogController.getStates);
 router.get('/catalogs/features', catalogController.getAllFeatures);
+
+// Ruta para obtener imágenes de Cloudinary
+router.get('/cloudinary/images', cloudinaryController.getCloudinaryImages);
 
 // Después van las rutas protegidas
 router.use(authenticate);


### PR DESCRIPTION
This commit introduces a new endpoint `/cloudinary/images` to retrieve images from Cloudinary. The `cloudinaryController.js` file is added to handle the API request and response logic, ensuring proper authentication and error handling.