### PR TITLE
feat: add notFoundController to handle 404 routes

### DIFF
--- a/src/controllers/notFoundController.js
+++ b/src/controllers/notFoundController.js
@@ -1,0 +1,13 @@
+const { ApiError } = require('../utils/ApiError');
+
+/**
+ * Controlador para manejar rutas no encontradas (404)
+ * @param {Object} req - Objeto de solicitud Express
+ * @param {Object} res - Objeto de respuesta Express
+ * @param {Function} next - Función next de Express
+ */
+const handleNotFound = (req, res, next) => {
+  next(new ApiError(404, 'Ruta no encontrada - La URL solicitada no existe en este servidor'));
+};
+
+module.exports = { handleNotFound };

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const routes = require('./routes');
 const { logger } = require('./utils/logger');
 const { initializeFirebase } = require('./config/firebase');
 const { checkDatabaseConnection } = require('./config/database');
+const { handleNotFound } = require('./controllers/notFoundController');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -46,6 +47,9 @@ app.use(express.static(path.join(__dirname, '../public')));
 
 // Routes
 app.use('/api', routes);
+
+// Manejo de rutas no encontradas para cualquier otra ruta
+app.all('*', handleNotFound);
 
 // Error handling
 app.use(errorHandler);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const propertyRoutes = require('./propertyRoutes');
 const authRoutes = require('./authRoutes');
+const { handleNotFound } = require('../controllers/notFoundController');
 
 // Ruta de prueba básica
 router.get('/', (req, res) => {
@@ -13,5 +14,9 @@ router.use('/auth', authRoutes);
 
 // Rutas de propiedades
 router.use('/properties', propertyRoutes);
+
+// Ruta wildcard para manejar rutas no encontradas (404)
+// Esta debe ser la última ruta
+router.all('*', handleNotFound);
 
 module.exports = router;


### PR DESCRIPTION
Introduce a new controller to handle 404 errors for routes that do not exist. This ensures consistent error handling and improves user experience by providing clear feedback when accessing invalid URLs. The controller is integrated into both the main application and the router to cover all possible routes.